### PR TITLE
Fix note tab navigation

### DIFF
--- a/src/components/Note.js
+++ b/src/components/Note.js
@@ -21,7 +21,7 @@ const Note = props => {
   };
   const handleKeyPress = (e) => {
     const key = e.key.toLowerCase();
-    if (key === 'enter' || (key === 'tab' && lyric.length < index)) {
+    if (key === 'enter' || (key === 'tab' && index < lyric.length - 1)) {
       setEdit(index + 1);
     }
   };


### PR DESCRIPTION
## Summary
- fix check that determines if Tab should move to the next note

## Testing
- `npm test` *(fails: `vitest: not found`)*