### PR TITLE
Fix alter output

### DIFF
--- a/src/utils/convert.js
+++ b/src/utils/convert.js
@@ -13,7 +13,7 @@ export const midiNumberToPitchMusicXML = (midiNumber, transpose = 0) => {
       _text: step,
     },
     alter: {
-      _text: alter > 0 ? `+${alter.toString()}` : alter.toString()
+      _text: alter.toString(),
     },
     octave: {
       _text: octave.toString(),


### PR DESCRIPTION
## Summary
- avoid prefixing positive alter values with `+`
- keep pitch conversion working with negative transposition

## Testing
- `npm test --silent` *(fails: vitest not found)*